### PR TITLE
changes to the docking viewer

### DIFF
--- a/src/apps/docking-viewer/index.ts
+++ b/src/apps/docking-viewer/index.ts
@@ -34,7 +34,7 @@ export { Viewer as DockingViewer };
 
 const DefaultViewerOptions = {
     extensions: ObjectKeys({}),
-    layoutIsExpanded: false,
+    layoutIsExpanded: true,
     layoutShowControls: true,
     layoutShowRemoteState: true,
     layoutControlsDisplay: 'reactive' as PluginLayoutControlsDisplay,
@@ -67,7 +67,7 @@ class Viewer {
                 layoutShowLog: true,
                 layoutShowLeftPanel: true,
 
-                viewportShowExpand: false,
+                viewportShowExpand: true,
                 viewportShowControls: false,
                 viewportShowSettings: false,
                 viewportShowSelectionMode: false,

--- a/src/apps/docking-viewer/index.ts
+++ b/src/apps/docking-viewer/index.ts
@@ -24,7 +24,7 @@ import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import '../../mol-util/polyfill';
 import { ObjectKeys } from '../../mol-util/type-helpers';
 import './index.html';
-import { ShowButtons, StructurePreset, ViewportComponent } from './viewport';
+import { InteractionsPreset, ShowButtons, ViewportComponent, StructurePreset } from './viewport';
 
 require('mol-plugin-ui/skin/light.scss');
 
@@ -34,7 +34,7 @@ export { Viewer as DockingViewer };
 
 const DefaultViewerOptions = {
     extensions: ObjectKeys({}),
-    layoutIsExpanded: true,
+    layoutIsExpanded: false,
     layoutShowControls: true,
     layoutShowRemoteState: true,
     layoutControlsDisplay: 'reactive' as PluginLayoutControlsDisplay,
@@ -60,14 +60,14 @@ class Viewer {
     static async create(elementOrId: string | HTMLElement, colors = [Color(0x992211), Color(0xDDDDDD)], showButtons = true) {
         const o = {
             ...DefaultViewerOptions, ...{
-                layoutIsExpanded: false,
-                layoutShowControls: false,
+                layoutIsExpanded: true,
+                layoutShowControls: true,
                 layoutShowRemoteState: false,
                 layoutShowSequence: true,
-                layoutShowLog: false,
+                layoutShowLog: true,
                 layoutShowLeftPanel: true,
 
-                viewportShowExpand: true,
+                viewportShowExpand: false,
                 viewportShowControls: false,
                 viewportShowSettings: false,
                 viewportShowSelectionMode: false,
@@ -179,6 +179,25 @@ class Viewer {
             await this.plugin.builders.structure.representation.applyPreset(structureProperties || structure, StructurePreset);
         });
     }
+
+    // modified function that doesn't apply merge
+    // defaults to InteractionsPreset
+    async loadStructuresFromUrls(sources: { url: string, format: BuiltInTrajectoryFormat, isBinary?: boolean }[]) {
+        const structures: { ref: string }[] = [];
+        for (const { url, format, isBinary } of sources) {
+            const data = await this.plugin.builders.data.download({ url, isBinary });
+            const trajectory = await this.plugin.builders.structure.parseTrajectory(data, format);
+            const model = await this.plugin.builders.structure.createModel(trajectory);
+            const modelProperties = await this.plugin.builders.structure.insertModelProperties(model);
+            const structure = await this.plugin.builders.structure.createStructure(modelProperties || model);
+            const structureProperties = await this.plugin.builders.structure.insertStructureProperties(structure);
+
+            structures.push({ ref: structureProperties?.ref || structure.ref });
+            this.plugin.behaviors.canvas3d.initialized.subscribe(async v => {
+                await this.plugin.builders.structure.representation.applyPreset(structureProperties || structure, InteractionsPreset);
+            });
+        }
+    }
 }
 
 type MergeStructures = typeof MergeStructures
@@ -212,5 +231,6 @@ const MergeStructures = PluginStateTransform.BuiltIn({
         });
     }
 });
+
 
 (window as any).DockingViewer = Viewer;

--- a/src/apps/docking-viewer/viewport.tsx
+++ b/src/apps/docking-viewer/viewport.tsx
@@ -194,7 +194,7 @@ const PocketPreset = StructureRepresentationPresetProvider({
     }
 });
 
-const InteractionsPreset = StructureRepresentationPresetProvider({
+export const InteractionsPreset = StructureRepresentationPresetProvider({
     id: 'preset-interactions',
     display: { name: 'Interactions' },
     params: () => PresetParams,
@@ -211,8 +211,8 @@ const InteractionsPreset = StructureRepresentationPresetProvider({
 
         const { update, builder, typeParams } = StructureRepresentationPresetProvider.reprBuilder(plugin, params);
         const representations = {
-            ligand: builder.buildRepresentation(update, components.ligand, { type: 'ball-and-stick', typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.3 }, color: 'element-symbol', colorParams: { carbonColor: { name: 'element-symbol', params: {} } } }, { tag: 'ligand' }),
-            ballAndStick: builder.buildRepresentation(update, components.surroundings, { type: 'ball-and-stick', typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.1, sizeAspectRatio: 1 }, color: 'element-symbol', colorParams: { carbonColor: { name: 'element-symbol', params: {} } } }, { tag: 'ball-and-stick' }),
+            ligand: builder.buildRepresentation(update, components.ligand, { type: 'ball-and-stick', typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.2 }, color: 'element-symbol', colorParams: { carbonColor: { name: 'element-symbol', params: {} } } }, { tag: 'ligand' }),
+            ballAndStick: builder.buildRepresentation(update, components.surroundings, { type: 'ball-and-stick', typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.1, sizeAspectRatio: 1 }, color: 'element-symbol', colorParams: { carbonColor: { name: 'chain-id', params: {} } } }, { tag: 'ball-and-stick' }),
             interactions: builder.buildRepresentation(update, components.interactions, { type: InteractionsRepresentationProvider, typeParams: { ...typeParams, material: CustomMaterial, includeParent: true, parentDisplay: 'between' }, color: InteractionTypeColorThemeProvider }, { tag: 'interactions' }),
             label: builder.buildRepresentation(update, components.surroundings, { type: 'label', typeParams: { ...typeParams, material: CustomMaterial, background: false, borderWidth: 0.1 }, color: 'uniform', colorParams: { value: Color(0x000000) } }, { tag: 'label' }),
         };


### PR DESCRIPTION
# Description
1. Sets the default view for the docking viewer to be the `Interaction` view instead of the `Structure` view.
2. Changes the load function for the docking viewer to not "merge", because our ligand + protein is already merged when we feed it in.
3. Show the controls/settings for the docking viewer (e.g. the LH and RH panels).
4. Changes the default color and size of the ligand + protein to make it visually better.

Todo:
1. Load the `State Tree` LHS panel by default instead of the `Home` view (I've asked on the Issues list how to do this)
2. Rebase on #1 so that polar hydrogens only shown by default

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`