### PR TITLE
Make component selector the default LHS for docking-viewer

### DIFF
--- a/src/apps/docking-viewer/index.ts
+++ b/src/apps/docking-viewer/index.ts
@@ -196,6 +196,7 @@ class Viewer {
             this.plugin.behaviors.canvas3d.initialized.subscribe(async v => {
                 await this.plugin.builders.structure.representation.applyPreset(structureProperties || structure, InteractionsPreset);
             });
+            this.plugin.behaviors.layout.leftPanelTabName.next('data')
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Makes the state tree diagram the default view for the docking-viewer, upon loading a structure.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`