### PR TITLE
show xtal ligand as line

### DIFF
--- a/src/apps/docking-viewer/index.ts
+++ b/src/apps/docking-viewer/index.ts
@@ -24,7 +24,7 @@ import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import '../../mol-util/polyfill';
 import { ObjectKeys } from '../../mol-util/type-helpers';
 import './index.html';
-import { InteractionsPreset, ShowButtons, ViewportComponent, StructurePreset } from './viewport';
+import { InteractionsPreset, ShowButtons, ViewportComponent, StructurePreset, XtalLigandPreset } from './viewport';
 
 require('mol-plugin-ui/skin/light.scss');
 
@@ -182,7 +182,7 @@ class Viewer {
 
     // modified function that doesn't apply merge
     // defaults to InteractionsPreset
-    async loadStructuresFromUrls(sources: { url: string, format: BuiltInTrajectoryFormat, isBinary?: boolean }[]) {
+    async loadStructuresFromUrls(sources: { url: string, format: BuiltInTrajectoryFormat, isBinary?: boolean }[], isXtalLigand: boolean = false) {
         const structures: { ref: string }[] = [];
         for (const { url, format, isBinary } of sources) {
             const data = await this.plugin.builders.data.download({ url, isBinary });
@@ -194,7 +194,7 @@ class Viewer {
 
             structures.push({ ref: structureProperties?.ref || structure.ref });
             this.plugin.behaviors.canvas3d.initialized.subscribe(async v => {
-                await this.plugin.builders.structure.representation.applyPreset(structureProperties || structure, InteractionsPreset);
+                await this.plugin.builders.structure.representation.applyPreset(structureProperties || structure, isXtalLigand ? XtalLigandPreset : InteractionsPreset);
             });
             this.plugin.behaviors.layout.leftPanelTabName.next('data')
         }

--- a/src/apps/docking-viewer/index.ts
+++ b/src/apps/docking-viewer/index.ts
@@ -24,7 +24,7 @@ import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import '../../mol-util/polyfill';
 import { ObjectKeys } from '../../mol-util/type-helpers';
 import './index.html';
-import { InteractionsPreset, ShowButtons, ViewportComponent, StructurePreset, XtalLigandPreset } from './viewport';
+import { InteractionsPreset, ShowButtons, ViewportComponent, StructurePreset, LigandAsLinePreset } from './viewport';
 
 require('mol-plugin-ui/skin/light.scss');
 
@@ -182,7 +182,7 @@ class Viewer {
 
     // modified function that doesn't apply merge
     // defaults to InteractionsPreset
-    async loadStructuresFromUrls(sources: { url: string, format: BuiltInTrajectoryFormat, isBinary?: boolean }[], isXtalLigand: boolean = false) {
+    async loadStructuresFromUrls(sources: { url: string, format: BuiltInTrajectoryFormat, isBinary?: boolean }[], showAsLine: boolean = false) {
         const structures: { ref: string }[] = [];
         for (const { url, format, isBinary } of sources) {
             const data = await this.plugin.builders.data.download({ url, isBinary });
@@ -194,7 +194,7 @@ class Viewer {
 
             structures.push({ ref: structureProperties?.ref || structure.ref });
             this.plugin.behaviors.canvas3d.initialized.subscribe(async v => {
-                await this.plugin.builders.structure.representation.applyPreset(structureProperties || structure, isXtalLigand ? XtalLigandPreset : InteractionsPreset);
+                await this.plugin.builders.structure.representation.applyPreset(structureProperties || structure, showAsLine ? LigandAsLinePreset : InteractionsPreset);
             });
             this.plugin.behaviors.layout.leftPanelTabName.next('data')
         }

--- a/src/apps/docking-viewer/viewport.tsx
+++ b/src/apps/docking-viewer/viewport.tsx
@@ -214,7 +214,7 @@ export const InteractionsPreset = StructureRepresentationPresetProvider({
             ligand: builder.buildRepresentation(update, components.ligand, { type: 'ball-and-stick', typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.2 }, color: 'element-symbol', colorParams: { carbonColor: { name: 'element-symbol', params: {} } } }, { tag: 'ligand' }),
             ballAndStick: builder.buildRepresentation(update, components.surroundings, { type: 'ball-and-stick', typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.1, sizeAspectRatio: 1 }, color: 'element-symbol', colorParams: { carbonColor: { name: 'chain-id', params: {} } } }, { tag: 'ball-and-stick' }),
             interactions: builder.buildRepresentation(update, components.interactions, { type: InteractionsRepresentationProvider, typeParams: { ...typeParams, material: CustomMaterial, includeParent: true, parentDisplay: 'between' }, color: InteractionTypeColorThemeProvider }, { tag: 'interactions' }),
-            label: builder.buildRepresentation(update, components.surroundings, { type: 'label', typeParams: { ...typeParams, material: CustomMaterial, background: false, borderWidth: 0.1 }, color: 'uniform', colorParams: { value: Color(0x000000) } }, { tag: 'label' }),
+            label: builder.buildRepresentation(update, components.surroundings, { type: 'label', typeParams: { ...typeParams, material: CustomMaterial, background: false, borderWidth: 0 }, textSize: 0.3, color: 'uniform', colorParams: { value: Color(0x808080) } }, { tag: 'label' }),
         };
 
         await update.commit({ revertOnError: true });
@@ -224,6 +224,35 @@ export const InteractionsPreset = StructureRepresentationPresetProvider({
         return { components, representations };
     }
 });
+
+export const XtalLigandPreset = StructureRepresentationPresetProvider({
+    id: 'preset-xtalLigand',
+    display: { name: 'Xtal' },
+    params: () => PresetParams,
+    async apply(ref, params, plugin) {
+        const structureCell = StateObjectRef.resolveAndCheck(plugin.state.data, ref);
+        const structure = structureCell?.obj?.data;
+        if (!structureCell || !structure) return {};
+
+        const components = {
+            ligand: await presetStaticComponent(plugin, structureCell, 'ligand'),
+            surroundings: await plugin.builders.structure.tryCreateComponentFromSelection(structureCell, ligandSurroundings, `surroundings`),
+            interactions: await presetStaticComponent(plugin, structureCell, 'ligand'),
+        };
+
+        const { update, builder, typeParams } = StructureRepresentationPresetProvider.reprBuilder(plugin, params);
+        const representations = {
+            ligand: builder.buildRepresentation(update, components.ligand, { type: 'line', typeParams: { ...typeParams, material: CustomMaterial}, color: 'element-symbol', colorParams: { carbonColor: { name: 'element-symbol', params: {} } } }, { tag: 'ligand' }),
+        };
+
+        await update.commit({ revertOnError: true });
+        await shinyStyle(plugin);
+        plugin.managers.interactivity.setProps({ granularity: 'element' });
+
+        return { components, representations };
+    }
+});
+
 
 export const ShowButtons = PluginConfig.item('showButtons', true);
 

--- a/src/apps/docking-viewer/viewport.tsx
+++ b/src/apps/docking-viewer/viewport.tsx
@@ -225,7 +225,7 @@ export const InteractionsPreset = StructureRepresentationPresetProvider({
     }
 });
 
-export const XtalLigandPreset = StructureRepresentationPresetProvider({
+export const LigandAsLinePreset = StructureRepresentationPresetProvider({
     id: 'preset-xtalLigand',
     display: { name: 'Xtal' },
     params: () => PresetParams,


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
1. Show xtal ligand as a line to visually distinguish
2. Make labels slightly smaller and gray, so they are less busy on the screen

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`